### PR TITLE
fix(guild-user): Passing none to edit_me

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1979,7 +1979,7 @@ class Guild(Hashable):
 
         .. note::
             To upload an avatar, or banner, a :term:`py:bytes-like object` must be passed in that
-            representes the image being uploaded. If this is done through a file
+            represents the image being uploaded. If this is done through a file
             then the file must be opened via ``open('filename`, 'rb')`` and
             the :term:`py:bytes-like object` is given through the use of ``fp.read()``.
 


### PR DESCRIPTION
## Summary

Previously, if the code:
- Passed none to all, it errors
- Passed an empty string to all, it fails
- Passed an empty string to only one of them, it works but then just resets a single one of them (undesired outcome)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x ] I have updated the documentation to reflect the changes.
- [x ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
